### PR TITLE
Change default preset to Laravel

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,8 +59,8 @@
         },
         "laravel-pint.preset": {
           "type": "string",
-          "enum": ["psr12", "laravel", "symfony"],
-          "default": "psr12",
+          "enum": ["laravel", "psr12", "symfony"],
+          "default": "laravel",
           "description": "Preset passed to the Laravel pint executable"
         },
         "laravel-pint.formatOnSave": {


### PR DESCRIPTION
Laravel Pint v2.0.0 [changed the default preset back to Laravel](https://github.com/laravel/pint/commit/012f927a4e45adc80a4c27c973cb4cf416f996e8).

Currently, this extension's default is set to `psr12`, which is inconsistent with the latest Laravel Pint. This leads to problems when relying on the default and not having a `pint.json`, as the extension formats code using the `psr12` preset, where elsewhere (in CI or terminal) `laravel` is used.

@d8vjork, maybe it's even better to leave out the `--preset` flag by default as @JeffBeltran suggested: https://github.com/open-southeners/vscode-laravel-pint/issues/7#issue-1284653040.