### PR TITLE
fix(schema): preset typo "psr-12" -> "psr12"

### DIFF
--- a/pint-schema.json
+++ b/pint-schema.json
@@ -12,7 +12,7 @@
           "enum": [
             "laravel",
             "symfony",
-            "psr-12"
+            "psr12"
           ]
         }
       ]


### PR DESCRIPTION
There is a typo in the schema "preset" section. The `pint` will not run correctly in `psr-12`, and jsonValidation is also problematic.

```
$ ./vendor/bin/pint


  Preset not found.
```
