### PR TITLE
chore(schema): change referenced schema to the schema in the extension

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -8,6 +8,5 @@ vsc-extension-quickstart.md
 **/.eslintrc.json
 **/*.map
 **/*.ts
-pint-schema.json
 scripts/**
 playground/**

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
 		"jsonValidation": [
 			{
 				"fileMatch": "pint.json",
-				"url": "https://raw.githubusercontent.com/open-southeners/vscode-laravel-pint/main/pint-schema.json"
+				"url": "./pint-schema.json"
 			}
 		]
 	},


### PR DESCRIPTION
## Description

Currently, it references a GitHub repository.

Inclusion in the extension itself allows pint.json autocompletion and validation to work without network access.

### Before

```
"jsonValidation": [
	{
		"fileMatch": "pint.json",
		"url": "https://raw.githubusercontent.com/open-southeners/vscode-laravel-pint/main/pint-schema.json"
	}
],
```

### After

```
"jsonValidation": [
	{
		"fileMatch": "pint.json",
		"url": "./pint-schema.json"
	}
],
```

## Note

If you are intentionally referencing a GitHub repository, please close this pull request. 🙇
