### PR TITLE
Pass workspace args into global pint command

### DIFF
--- a/src/ModuleResolver.ts
+++ b/src/ModuleResolver.ts
@@ -10,10 +10,10 @@ import { canExecuteFile, getWorkspaceConfig, resolvePathFromWorkspaces } from ".
 export class ModuleResolver {
   constructor(private loggingService: LoggingService) { }
 
-  public async getGlobalPintCommand(input: string): Promise<PhpCommand> {
+  public async getGlobalPintCommand(args: Array<string>): Promise<PhpCommand> {
     const globalPintPath = await commandExists('pint');
 
-    return new PhpCommand(globalPintPath, [input]);
+    return new PhpCommand(globalPintPath, args);
   }
 
   public async getPintCommand(workspaceFolder: WorkspaceFolder, input?: string): Promise<PhpCommand | undefined> {
@@ -21,7 +21,7 @@ export class ModuleResolver {
       this.loggingService.logDebug(UNTRUSTED_WORKSPACE_USING_GLOBAL_PINT);
 
       // This doesn't respect fallbackToGlobal config
-      return this.getGlobalPintCommand(input || workspaceFolder.uri.fsPath);
+      return this.getGlobalPintCommand(await this.getPintConfigAsArgs(workspaceFolder, input));
     }
 
     const executableArr = await resolvePathFromWorkspaces(
@@ -36,7 +36,7 @@ export class ModuleResolver {
     const fallbackToGlobal = getWorkspaceConfig('fallbackToGlobalBin') && commandExists.sync('pint');
 
     if (!isExecutable && fallbackToGlobal) {
-      return this.getGlobalPintCommand(input || workspaceFolder.uri.fsPath);
+      return this.getGlobalPintCommand(await this.getPintConfigAsArgs(workspaceFolder, input));
     }
 
     if (!isExecutable && !fallbackToGlobal) {

--- a/src/PintEditService.ts
+++ b/src/PintEditService.ts
@@ -190,7 +190,7 @@ export default class PintEditService implements Disposable {
 
     let command = workspaceFolder
       ? await this.moduleResolver.getPintCommand(workspaceFolder, file.fsPath)
-      : await this.moduleResolver.getGlobalPintCommand(file.fsPath);
+      : await this.moduleResolver.getGlobalPintCommand([file.fsPath]);
 
     if (!command) {
       this.statusBar.update(FormatterStatus.Error);


### PR DESCRIPTION
When falling back to the global pint command, I realized that the workspace config isn't being used.

I haven't tested all the use cases thoroughly yet, so leaving this as a draft for the moment.