### PR TITLE
Set the client workspace directory path into PhpCommand

### DIFF
--- a/src/ModuleResolver.ts
+++ b/src/ModuleResolver.ts
@@ -45,7 +45,11 @@ export class ModuleResolver {
       return;
     }
 
-    return new PhpCommand(executable, await this.getPintConfigAsArgs(workspaceFolder, input));
+    const cmd = getWorkspaceConfig('executablePath', path.posix.join(...DEFAULT_EXEC_PATH));
+
+    const cwd = executable.replace( cmd, '' );
+
+    return new PhpCommand(cmd, await this.getPintConfigAsArgs(workspaceFolder, input), cwd);
   }
 
   public async getPintCommandWithinSail(workspaceFolder: WorkspaceFolder, input?: string): Promise<PhpCommand | undefined> {

--- a/src/PintEditService.ts
+++ b/src/PintEditService.ts
@@ -200,7 +200,7 @@ export default class PintEditService implements Disposable {
       return false;
     }
 
-    command.run(workspaceFolder?.uri.fsPath);
+    command.run();
 
     this.loggingService.logDebug(RUNNING_PINT_ON_PATH, { command: command.toString() });
 

--- a/src/PintEditService.ts
+++ b/src/PintEditService.ts
@@ -200,7 +200,7 @@ export default class PintEditService implements Disposable {
       return false;
     }
 
-    command.run();
+    command.run(workspaceFolder?.uri.fsPath);
 
     this.loggingService.logDebug(RUNNING_PINT_ON_PATH, { command: command.toString() });
 


### PR DESCRIPTION
Related to the issue #50 

TL:DR; `Pint` requires access to the current project path using `getcwd()`. The command must be executed within the project itself.

I added variables into the `getPintCommand()` method in `ModuleResolver.ts` file at line `48`: 

```
const cmd = getWorkspaceConfig('executablePath', path.posix.join(...DEFAULT_EXEC_PATH));

const cwd = executable.replace( cmd, '' );

return new PhpCommand(cmd, await this.getPintConfigAsArgs(workspaceFolder, input), cwd);
```

instead of 
```
return new PhpCommand(executable, await this.getPintConfigAsArgs(workspaceFolder, input));
```


In that matter, even in a `multi-workspace` environment, the path to the client workspace directory is respected.