### PR TITLE
feat: Add Laravel pint --dirty option

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,6 +119,12 @@
           "type": "string",
           "markdownDescription": "%ext.config.sailExecutablePath%",
           "scope": "resource"
+        },
+        "laravel-pint.dirtyOnly": {
+          "default": false,
+          "type": "boolean",
+          "markdownDescription": "%ext.config.dirtyOnly%",
+          "scope": "resource"
         }
       }
     },

--- a/package.nls.json
+++ b/package.nls.json
@@ -6,5 +6,6 @@
   "ext.config.executablePath": "**Workspace-relative path** to the executable binary. Default: `vendor/bin/pint`.",
   "ext.config.fallbackToGlobalBin": "Enable/disable fallback to global composer Pint binary in case local wasn't found. Default: `true`.",
   "ext.config.runInLaravelSail": "Run formatting through Docker using [Laravel Sail](https://laravel.com/docs/master/sail). This will ignore `#laravel-pint.executablePath#`.",
-  "ext.config.sailExecutablePath": "Path to Laravel Sail executable, only used if is enabled `#laravel-pint.runInLaravelSail#`. Default: `vendor/bin/sail`."
+  "ext.config.sailExecutablePath": "Path to Laravel Sail executable, only used if is enabled `#laravel-pint.runInLaravelSail#`. Default: `vendor/bin/sail`.",
+  "ext.config.dirtyOnly": "Enable/disable formatting only on **active workspace** dirty files. Only work with command `Format active workspace files using Laravel Pint`."
 }

--- a/src/PintEditService.ts
+++ b/src/PintEditService.ts
@@ -176,10 +176,10 @@ export default class PintEditService implements Disposable {
       return;
     }
 
-    await this.formatFile(workspaceFolder.uri);
+    await this.formatFile(workspaceFolder.uri, true);
   }
 
-  public async formatFile(file: Uri) {
+  public async formatFile(file: Uri, isFormatWorkspace = false) {
     if (this.isDocumentExcluded(file)) {
       this.loggingService.logWarning(`The file "${file.fsPath}" is excluded either by you or by Laravel Pint`);
 
@@ -189,7 +189,7 @@ export default class PintEditService implements Disposable {
     const workspaceFolder = workspace.getWorkspaceFolder(file);
 
     let command = workspaceFolder
-      ? await this.moduleResolver.getPintCommand(workspaceFolder, file.fsPath)
+      ? await this.moduleResolver.getPintCommand(workspaceFolder, file.fsPath, isFormatWorkspace)
       : await this.moduleResolver.getGlobalPintCommand([file.fsPath]);
 
     if (!command) {

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -33,6 +33,7 @@ suite('Extension Test Suite', () => {
     assert.strictEqual(config.get<PresetOptions>('preset'), 'auto');
     assert.strictEqual(config.get<boolean>('runInLaravelSail'), false);
     assert.strictEqual(config.get<string>('sailExecutablePath'), '');
+    assert.strictEqual(config.get<boolean>('dirtyOnly'), false);
 	});
 	
   test('Build command with config args', async () => {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -9,6 +9,7 @@ export interface ExtensionConfig {
   fallbackToGlobalBin: boolean
   runInLaravelSail: boolean
   sailExecutablePath: string
+  dirtyOnly: boolean
 }
 
 export interface ExtensionFormattingOptions {


### PR DESCRIPTION
Add config to run Laravel pint with `--dirty` option for command `Format active workspace files using Laravel Pint`