### PR TITLE
Add support for using VSCode's php.validate.executablePath setting

### DIFF
--- a/src/PhpCommand.ts
+++ b/src/PhpCommand.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import { platform } from "node:os";
+import { workspace } from "vscode";
 
 export default class PhpCommand {
   constructor(private cmd: string, private args: Array<string>, private cwd?: string) { }
@@ -9,7 +10,7 @@ export default class PhpCommand {
       this.args = [this.cmd].concat(this.args);
 
       // TODO: Fail when no PHP command, check with command-exists package
-      this.cmd = 'php';
+      this.cmd = workspace.getConfiguration('php.validate').get('executablePath', 'php');
     }
 
     const exec = spawn(this.cmd, this.args, {


### PR DESCRIPTION
### Summary

This PR adds support for using the PHP executable path specified in VSCode's
`php.validate.executablePath` setting. If this setting is configured in the user's
VSCode environment, Laravel Pint will now prioritize using this path for PHP execution.
