### PR TITLE
Fix casing on case-insensitive filesystems 

### DIFF
--- a/src/PintEditService.ts
+++ b/src/PintEditService.ts
@@ -1,6 +1,6 @@
 import { readFile } from "fs-extra";
 import path = require("node:path");
-import fs = require("node:fs");
+import fs = require("node:fs/promises");
 import { Disposable, TextEditor, Uri, workspace, languages, RelativePattern, TextDocument, TextEdit, WorkspaceFolder, window, FileSystemWatcher } from "vscode";
 import { CONFIG_FILE_NAME } from "./constants";
 import { LoggingService } from "./LoggingService";
@@ -181,7 +181,7 @@ export default class PintEditService implements Disposable {
   }
 
   public async formatFile(file: Uri, isFormatWorkspace = false) {
-    let filePath = fs.realpathSync.native(file.fsPath);
+    let filePath = await fs.realpath(file.fsPath);
 
     if (this.isDocumentExcluded(file)) {
       this.loggingService.logWarning(`The file "${filePath}" is excluded either by you or by Laravel Pint`);

--- a/src/PintEditService.ts
+++ b/src/PintEditService.ts
@@ -1,5 +1,6 @@
 import { readFile } from "fs-extra";
 import path = require("node:path");
+import fs = require("node:fs");
 import { Disposable, TextEditor, Uri, workspace, languages, RelativePattern, TextDocument, TextEdit, WorkspaceFolder, window, FileSystemWatcher } from "vscode";
 import { CONFIG_FILE_NAME } from "./constants";
 import { LoggingService } from "./LoggingService";
@@ -180,8 +181,10 @@ export default class PintEditService implements Disposable {
   }
 
   public async formatFile(file: Uri, isFormatWorkspace = false) {
+    let filePath = fs.realpathSync.native(file.fsPath);
+
     if (this.isDocumentExcluded(file)) {
-      this.loggingService.logWarning(`The file "${file.fsPath}" is excluded either by you or by Laravel Pint`);
+      this.loggingService.logWarning(`The file "${filePath}" is excluded either by you or by Laravel Pint`);
 
       return false;
     }
@@ -189,8 +192,8 @@ export default class PintEditService implements Disposable {
     const workspaceFolder = workspace.getWorkspaceFolder(file);
 
     let command = workspaceFolder
-      ? await this.commandResolver.getPintCommand(workspaceFolder, file.fsPath, isFormatWorkspace)
-      : await this.commandResolver.getGlobalPintCommand([file.fsPath]);
+      ? await this.commandResolver.getPintCommand(workspaceFolder, filePath, isFormatWorkspace)
+      : await this.commandResolver.getGlobalPintCommand([filePath]);
 
     if (!command) {
       this.statusBar.update(FormatterStatus.Error);


### PR DESCRIPTION
I noticed an issue where vscode seems to be passing a cached filename on case-insensitive file systems on file events. This PR pulls the latest filename from the system by grabbing the current casing before passing off the file path in `PintEditService.formatFile` function.

Steps to reproduce:

0. Enable autoformatting on file save in `.vscode/settings.json`

```
{
  "editor.formatOnSave": true,
  "editor.codeActionsOnSave": {
    "source.fixAll.eslint": "explicit"
  },
  "laravel-pint.enable": true,
  "laravel-pint.configPath": "pint.json",
  "laravel-pint.executablePath": "vendor/bin/pint",
  "[php]": {
    "editor.defaultFormatter": "open-southeners.laravel-pint"
  }
}

```
1. Setup a `pint.json` config file like so:
```
{
  "preset": "laravel",
  "rules": {
    "psr_autoloading": true
  }
}
```
2. In VSCode, Create test file at `app/Actions/wrongCasing.php` and save it with autoformatting: 
```<?PHP

namespace App\Actions;

class wrongCasing {}
```
3. Rename the file to the proper casing in vscode `app/Actions/wrongCasing.php` > `app/Actions/wrongCasing2.php` > `app/Actions/WrongCasing.php`
4. Save the file to trigger formatting.

The file itself still has a class name of `wrongCasing` instead of `WrongCasing` derived from the filename.