### PR TITLE
Command feedback/error handling + logging

### DIFF
--- a/src/PhpCommand.ts
+++ b/src/PhpCommand.ts
@@ -5,7 +5,7 @@ import { workspace } from "vscode";
 export default class PhpCommand {
   constructor(private cmd: string, private args: Array<string>, private cwd?: string) { }
 
-  run(cwd?: string) {
+  run(cwd?: string): Promise<{ output: string, code: number|null }> {
     if (platform() === "win32") {
       this.args = [this.cmd].concat(this.args);
 
@@ -16,6 +16,29 @@ export default class PhpCommand {
     const exec = spawn(this.cmd, this.args, {
       cwd: cwd || this.cwd,
       shell: platform() === "win32" ? true : undefined
+    });
+    
+    const output: Array<string> = [];
+
+    const onOutput = (data: string) => {
+      output.push(data);
+    };
+
+    exec.stdout.on('data', onOutput);
+    exec.stderr.on('data', onOutput);
+
+    return new Promise((resolve, reject) => {
+      exec.on('error', reject);
+      exec.on('exit', (code) => {
+        if (code !== 0) {
+          reject(new Error(`Command failed with exit code ${code} and output: ${output.join('')}`));
+        } else {
+          resolve({
+            code,
+            output: output.join(''),
+          });
+        }
+      });
     });
   }
 

--- a/src/PintEditService.ts
+++ b/src/PintEditService.ts
@@ -203,25 +203,25 @@ export default class PintEditService implements Disposable {
       return false;
     }
 
-    this.statusBar.update(FormatterStatus.Loading);
+    const editCount = this.statusBar.update(FormatterStatus.Loading);
 
     this.loggingService.logDebug(RUNNING_PINT_ON_PATH, { command: command.toString() });
 
-    try {
-      const { code, output } = await command.run();
-
+    command.run().then(({ output, code }) => {;
       this.loggingService.logDebug(output, { code });
 
-      this.statusBar.update(FormatterStatus.Success);
-
-      return true;
-    } catch (error) {
-      this.statusBar.update(FormatterStatus.Error);
+      if (this.statusBar.getEditCount() === editCount) {
+        this.statusBar.update(FormatterStatus.Success);
+      }
+    }).catch((error) => {
+      if (this.statusBar.getEditCount() === editCount) {
+        this.statusBar.update(FormatterStatus.Error);
+      }
 
       this.loggingService.logError(SOMETHING_WENT_WRONG_RUNNING_PINT, error);
+    });
 
-      return false;
-    }
+    return true;
   }
 
   private provideEdits = async (document: TextDocument): Promise<TextEdit[]> => {

--- a/src/PintEditService.ts
+++ b/src/PintEditService.ts
@@ -4,7 +4,7 @@ import fs = require("node:fs/promises");
 import { Disposable, TextEditor, Uri, workspace, languages, RelativePattern, TextDocument, TextEdit, WorkspaceFolder, window, FileSystemWatcher } from "vscode";
 import { CONFIG_FILE_NAME } from "./constants";
 import { LoggingService } from "./LoggingService";
-import { ENABLING_PINT_FOR_WORKSPACE, FORMAT_WORKSPACE_NON_ACTIVE_DOCUMENT, RUNNING_PINT_ON_PATH, SOMETHING_WENT_WRONG_FINDING_EXECUTABLE, UPDATING_EXTENSION_EXCLUDE_PATTERNS } from "./message";
+import { ENABLING_PINT_FOR_WORKSPACE, FORMAT_WORKSPACE_NON_ACTIVE_DOCUMENT, RUNNING_PINT_ON_PATH, SOMETHING_WENT_WRONG_FINDING_EXECUTABLE, UPDATING_EXTENSION_EXCLUDE_PATTERNS, SOMETHING_WENT_WRONG_RUNNING_PINT } from "./message";
 import { CommandResolver } from "./CommandResolver";
 import { PintEditProvider } from "./PintEditProvider";
 import { FormatterStatus, StatusBar } from "./StatusBar";
@@ -203,13 +203,25 @@ export default class PintEditService implements Disposable {
       return false;
     }
 
-    command.run();
+    this.statusBar.update(FormatterStatus.Loading);
 
     this.loggingService.logDebug(RUNNING_PINT_ON_PATH, { command: command.toString() });
 
-    this.statusBar.update(FormatterStatus.Success);
+    try {
+      const { code, output } = await command.run();
 
-    return true;
+      this.loggingService.logDebug(output, { code });
+
+      this.statusBar.update(FormatterStatus.Success);
+
+      return true;
+    } catch (error) {
+      this.statusBar.update(FormatterStatus.Error);
+
+      this.loggingService.logError(SOMETHING_WENT_WRONG_RUNNING_PINT, error);
+
+      return false;
+    }
   }
 
   private provideEdits = async (document: TextDocument): Promise<TextEdit[]> => {

--- a/src/StatusBar.ts
+++ b/src/StatusBar.ts
@@ -19,6 +19,7 @@ interface StatusBarResultMeta {
 
 export class StatusBar {
   private statusBarItem: StatusBarItem;
+  private editCount: number = 0;
   
   constructor() {
     // Setup the statusBarItem
@@ -34,7 +35,7 @@ export class StatusBar {
     this.statusBarItem.show();
   }
   
-  public update(result: FormatterStatus, meta?: StatusBarResultMeta): void {
+  public update(result: FormatterStatus, meta?: StatusBarResultMeta): number {
     this.statusBarItem.text = `$(${result.toString()}) Laravel Pint`;
     
     if (result === FormatterStatus.Disabled) {
@@ -86,9 +87,15 @@ export class StatusBar {
     }
     
     this.statusBarItem.show();
+
+    return ++this.editCount;
   }
 
   public hide() {
     this.statusBarItem.hide();
+  }
+
+  public getEditCount(): number {
+    return this.editCount;
   }
 }

--- a/src/StatusBar.ts
+++ b/src/StatusBar.ts
@@ -8,6 +8,7 @@ export enum FormatterStatus {
   Warn = "warning",
   Error = "alert",
   Disabled = "circle-slash",
+  Loading = "loading~spin",
 }
 
 // TODO: Not there yet...
@@ -74,6 +75,14 @@ export class StatusBar {
       );
 
       this.statusBarItem.tooltip = "Laravel Pint ran successfully fixing this file";
+    }
+
+    if (result === FormatterStatus.Loading) {
+      this.statusBarItem.backgroundColor = new ThemeColor(
+        "statusBarItem.prominentBackground"
+      );
+
+      this.statusBarItem.tooltip = "Laravel Pint is running on this file";
     }
     
     this.statusBarItem.show();

--- a/src/message.ts
+++ b/src/message.ts
@@ -4,6 +4,7 @@ export const SAIL_CANNOT_BE_EXECUTED = 'Executable not readable or lacks permiss
 export const PINT_CANNOT_BE_EXECUTED = 'Executable not readable or lacks permissions for Laravel Pint.';
 export const SOMETHING_WENT_WRONG_FORMATTING = 'Something went wrong! Active document does not support formatting. Please check before create an issue on';
 export const SOMETHING_WENT_WRONG_FINDING_EXECUTABLE = 'Something went wrong! Executable does not exists or lacks permissions. Please check before create an issue on';
+export const SOMETHING_WENT_WRONG_RUNNING_PINT = 'Something went wrong! Laravel Pint returned an error.';
 export const RESTART_TO_ENABLE = 'Restart or reload this VSCode project window to enable/disable Laravel Pint extension.';
 export const FORMAT_WORKSPACE_NON_ACTIVE_DOCUMENT = 'There is active workspace. Please open a document and run this command leaving this document open.';
 


### PR DESCRIPTION
Whilst debugging an issue with my environment (turns out, my issue wasn't the fault of this extension), I noticed that this extension doesn't check the output of the Pint command to see if it ran successfully or not, and provides no logging about its status. So when the command was failing for me, and trying to output an error, I saw nothing in the debug logs of this extension and it assumed the process had ran successfully.

This PR:

1. Adds a loading spinner whilst the pint process is running
2. Checks the exit code of the pint process and reports success or failure accordingly
3. Debug logs the stdout/stderr output of the pint process