### PR TITLE
fix: Extension not formatting files

### DIFF
--- a/src/CommandResolver.ts
+++ b/src/CommandResolver.ts
@@ -128,6 +128,8 @@ export class CommandResolver {
       }
     }
 
+    executableArgsAsArray.push('--repair');
+
     return executableArgsAsArray;
   }
 }

--- a/src/PhpCommand.ts
+++ b/src/PhpCommand.ts
@@ -17,6 +17,8 @@ export default class PhpCommand {
       cwd: cwd || this.cwd,
       shell: platform() === "win32" ? true : undefined
     });
+
+    exec.stdin.end();
   }
 
   toString() {


### PR DESCRIPTION
This PR makes Pint always run with the --repair flag.

### TLDR
Without this flag, Pint does not apply any formatting when executed via the VSCode extension host, even though the same command works as expected in a terminal. With --repair, Pint consistently applies fixes inside the extension.


### Background & Investigation

I went through a lot of trial and error trying to understand the issue:

- Initial behavior: Pint ran fine in the terminal (with or without --repair), but in the extension it exited without formatting the file.

-	What I tried:
	  -	Verified the cwd was correct (project root).
	  -	Forced execution via php vendor/bin/pint instead of relying on the shebang.
	  -	Tested both spawn and exec, and added listeners for stdout, stderr, exit, and close.
	  -	Tried with --no-cache.
	  -	Explicitly separated args with -- file.php.
	  -	Experimented with waiting for the spawn process to exit. This caused the extension to hang until I explicitly closed stdin in the child process.
	  
-	Findings:
	  -	Without --repair, the process appeared to run but didn’t apply changes.
	  -	With --repair, Pint behaved consistently and files were correctly formatted.
	  -	The exact reason why Pint behaves differently under Node’s spawn (non-TTY) vs. an interactive terminal remains unclear.
	  -	This exact issue is also present in the official Laravel VSCode extension, which recently added Pint support. Applying the same --repair flag there resolves the problem as well.


### Conclusion

Although the root cause is still unknown, using --repair is the only reliable way I found to make Pint apply fixes in the VSCode extension environment. While this may be a workaround, it is functional and unblocks the extension.