### PR TITLE
Non-rule pint schema updates

### DIFF
--- a/pint-schema.json
+++ b/pint-schema.json
@@ -40,9 +40,9 @@
         "type": "string"
       }
     },
-    "cache-folder": {
+    "cache-file": {
       "type": "string",
-      "description": "Cache file path for customise it. Defaults to tmp folder that your operating system uses."
+      "description": "The path to the cache file to use (defaults to a file in the temp folder used by PHP)."
     },
     "rules": {
       "type": "object",

--- a/pint-schema.json
+++ b/pint-schema.json
@@ -13,7 +13,8 @@
             "laravel",
             "symfony",
             "psr12",
-            "per"
+            "per",
+            "empty"
           ]
         }
       ]


### PR DESCRIPTION
The `pint-schema.json` file has two small issues:

1. The `empty` preset is missing from the `preset` enum.
    - The valid preset list can be seen here: https://github.com/laravel/pint/blob/v1.26.0/app/Factories/ConfigurationResolverFactory.php#L19-L25

2. The `cache-folder` property is not correct. The option is `cache-file`.
    - The usage can be seen here: https://github.com/laravel/pint/blob/v1.26.0/app/Repositories/ConfigurationJsonRepository.php#L59

This PR addresses these two issues.